### PR TITLE
Add Chinese localization

### DIFF
--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -1,0 +1,8 @@
+{
+  "@metadata": {
+    "authors": [
+      "Lakejason0"
+    ]
+  },
+  "cloudflare-desc": "页面更新时清除Cloudflare缓存"
+}

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -1,0 +1,8 @@
+{
+  "@metadata": {
+    "authors": [
+      "Lakejason0"
+    ]
+  },
+  "cloudflare-desc": "頁面更新時清除Cloudflare快取"
+}


### PR DESCRIPTION
Thank you for your work on another Cloudflare extension! It's been a long time for a new usable CF extension, and I really would like to have one despite my poor PHP skills. Anyway, I do localizations for MediaWiki works and the `@metadata` part is for marking authors, which will be automatically added if you request your extension to be translatable via translatewiki.net.
I also left a comment on your blog. That's pretty useful actually.