### PR TITLE
Purge URL when a page is deleted

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cloudflare",
-	"version": "0.1.3",
+	"version": "0.2",
 	"author": [
 		"harugon"
 	],
@@ -9,7 +9,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.37.0"
 	},
 	"MessagesDirs": {
 		"Cloudflare": [
@@ -28,6 +28,7 @@
 	},
 	"Hooks": {
 		"LocalFilePurgeThumbnails": "main",
+		"PageDeleteComplete": "main",
 		"TitleSquidURLs": "main"
 	},
 	"ConfigRegistry": {

--- a/includes/HookHandler.php
+++ b/includes/HookHandler.php
@@ -6,11 +6,13 @@ use Cloudflare\API as Cloudflare_API;
 use Config;
 use File;
 use MediaWiki\Hook\LocalFilePurgeThumbnailsHook;
+use MediaWiki\Page\Hook\PageDeleteCompleteHook;
 use MediaWiki\Hook\TitleSquidURLsHook;
 use Title;
 
 class HookHandler implements
 	TitleSquidURLsHook,
+	PageDeleteCompleteHook,
 	LocalFilePurgeThumbnailsHook
 {
 	/** @var Config */
@@ -52,6 +54,23 @@ class HookHandler implements
 			}, $urls );
 			$purge = $this->purge( $purgeURL );
 		}
+	}
+
+	/**
+	 * Purge URL when a page is deleted
+	 *
+	 * MediaWiki\Page\ProperPageIdentity $page
+	 * MediaWiki\Permissions\Authority $deleter
+	 * string $reason
+	 * int $pageID
+	 * MediaWiki\Revision\RevisionRecord $deletedRev
+	 * ManualLogEntry $logEntry
+	 * int $archivedRevisionCount
+	 */
+	public function onPageDeleteComplete( $page, $deleter, $reason, $pageID, $deletedRev, $logEntry, $archivedRevisionCount ) {
+		$title = $page->getTitle();
+		$url = $title->getFullURL();
+		$purge = $this->purge( [ $url ] );
 	}
 
 	/**


### PR DESCRIPTION
Hi! Thanks for developing this extension. I was mid-way through developing the same idea when I found you had already implemented it. Would love to contribute!

When a page is deleted, I think it's desirable to update the Cloudflare cache too, so that it doesn't show up anymore. This pull request accomplishes that. I also raised the MediaWiki requirement to 1.37+ because https://www.mediawiki.org/wiki/Manual:Hooks/PageDeleteComplete requires so.

Kind regards,