### PR TITLE
Fix typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "autoload": {
     "psr-4": {
-      "MediaWiki\\Extension\\Clouflare\\": "includes/"
+      "MediaWiki\\Extension\\Cloudflare\\": "includes/"
     }
   },
   "require": {


### PR DESCRIPTION
This caused an error message in our Docker builds, as composer.json does not match the class namespace.