### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this extension are documented in this file.
+
+## 0.4.0
+
+This release adds Cloudflare API Token authentication support and improves MediaWiki purge handling.
+
+### Added
+
+- Added `CloudflareAPIToken` configuration support.
+- Added shared URL expansion logic via `UrlExpander`.
+
+### Changed
+
+- Cloudflare API Token authentication is now the recommended method.
+- `CloudflareEmail` / `CloudflareAPIKey` remain supported as a legacy fallback for backward compatibility.
+- Replaced deprecated `MWException` usage.
+- Updated hook implementations and PHPDoc annotations.
+
+Thanks to @hexmode for the contribution.
+
+## 0.2.0 (2023-10-07)
+
+- Migrated to utilizing EventRelayer for cache purging, moving away from the previous hook-based implementation.
+- Removed the dependency on cloudflare/sdk. This change eliminates the need to run `composer install --no-dev` in the extension directory when installing from Git, easing the installation process.
+
+## 0.1.2
+
+- 設定が不正だったのを修正
+
+## 0.1.1
+
+パージするコンテンツを指定できるように
+
+- 設定項目追加 `$wgCloudflarePurgePage`, `$wgCloudflarePurgeFile`
+- i18n 追加 en.json, ja.json
+
+## 0.1.0
+
+初回リリース

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cloudflare",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"author": [
 		"harugon"
 	],

--- a/includes/CloudflareAPIRequester.php
+++ b/includes/CloudflareAPIRequester.php
@@ -60,7 +60,7 @@ class CloudflareAPIRequester {
 		} elseif ( !empty( $email ) && !empty( $apiKey ) ) {
 			wfDeprecatedMsg(
 				'CloudflareEmail and CloudflareAPIKey are deprecated, use CloudflareAPIToken instead',
-				'0.3.0'
+				'0.4.0'
 			);
 			$headers['X-Auth-Email'] = $email;
 			$headers['X-Auth-Key'] = $apiKey;


### PR DESCRIPTION
Bump the extension to **0.4.0** and prepare the release.

## Changes

- `extension.json`: version `0.3.0` → `0.4.0`
- `includes/CloudflareAPIRequester.php`: update the `CloudflareEmail` / `CloudflareAPIKey` deprecation notice `since` version to `0.4.0` (the version introducing Cloudflare API Token auth)
- `CHANGELOG.md`: new file documenting the 0.4.0 release and prior history

## 0.4.0 release notes

This release adds Cloudflare API Token authentication support and improves MediaWiki purge handling.

### Added
- Added `CloudflareAPIToken` configuration support.
- Added shared URL expansion logic via `UrlExpander`.

### Changed
- Cloudflare API Token authentication is now the recommended method.
- `CloudflareEmail` / `CloudflareAPIKey` remain supported as a legacy fallback for backward compatibility.
- Replaced deprecated `MWException` usage.
- Updated hook implementations and PHPDoc annotations.

Thanks to @hexmode for the contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V16j4Wg9oTqpRDE1tW4Q8N)_